### PR TITLE
Fix separator between nodes opt and Customer label

### DIFF
--- a/modules/ROOT/pages/guide-import-csv.adoc
+++ b/modules/ROOT/pages/guide-import-csv.adoc
@@ -254,7 +254,7 @@ The tool is located in `<neo4j-home>/bin/neo4j-admin` and is used as follows:
 [source, shell]
 ----
 bin/neo4j-admin import --id-type=STRING \
-                       --nodes:Customer=customers.csv --nodes=products.csv  \
+                       --nodes=Customer=customers.csv --nodes=products.csv  \
                        --nodes="orders_header.csv,orders1.csv,orders2.csv" \
                        --relationships:CONTAINS=order_details.csv \
                        --relationships:ORDERED="customer_orders_header.csv,orders1.csv,orders2.csv"


### PR DESCRIPTION
Results in error `Missing required option '--nodes=[<label>[:<label>]...=]<files>'` as is.

See also https://neo4j.com/docs/operations-manual/current/tutorial/import-tool/#import-tool-same-label-for-every-node-example.