### PR TITLE
Spark changes

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -78,9 +78,6 @@
 ** link:https://neo4j.com/developer/spark/[Neo4j Connector for Apache Spark]
 ** link:https://neo4j.com/labs/kafka/4.0/[Neo4j Connector for Apache Kafka]
 ** link:https://neo4j.com/bi-connector/[Neo4j Connector for Business Intelligence]
-** xref:elastic-search.adoc[Elastic-Search]
-** xref:mongodb.adoc[MongoDB]
-** xref:cassandra.adoc[Cassandra]
 
 * xref:graph-apps:index.adoc[Graph Apps]
 ** xref:graph-apps:featured.adoc[Featured Graph Apps]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -75,7 +75,9 @@
 ** xref:ruby-course.adoc[Tutorial: Ruby &amp; Rails (Books)]
 
 * xref:integration.adoc[Neo4j Tools &amp; Integrations]
-** xref:apache-spark.adoc[Apache Spark]
+** link:https://neo4j.com/developer/spark/[Neo4j Connector for Apache Spark]
+** link:https://neo4j.com/labs/kafka/4.0/[Neo4j Connector for Apache Kafka]
+** link:https://neo4j.com/bi-connector/[Neo4j Connector for Business Intelligence]
 ** xref:elastic-search.adoc[Elastic-Search]
 ** xref:mongodb.adoc[MongoDB]
 ** xref:cassandra.adoc[Cassandra]

--- a/modules/ROOT/pages/apache-spark.adoc
+++ b/modules/ROOT/pages/apache-spark.adoc
@@ -6,6 +6,10 @@
 :tags: integrations, spark, tools
 :description: There are various ways to beneficially use Neo4j with http://spark.apache.org[Apache Spark], here we will list some approaches and point to solutions that enable you to leverage your Spark infrastructure with Neo4j.
 
+[NOTE]
+**This approach is deprecated** in favor of the link:/developer/spark[Neo4j Connector for Apache Spark].  This page is being maintained
+for reference, but is not current or supported.  Please consult the Neo4j Connector for Apache Spark for the latest supported connector.
+
 .Goals
 [abstract]
 {description}
@@ -41,6 +45,10 @@ Spark might be better suited for larger datasets or more intensive compute opera
 == Neo4j-Spark-Connector
 
 The https://github.com/neo4j-contrib/neo4j-spark-connector[Neo4j Spark Connector] uses the binary Bolt protocol to transfer data from and to a Neo4j server.
+
+[NOTE]
+**The information on this page refers to the old (2.4.5 release) of the spark connector**.   For more up to date information, an easier and more modern API, 
+consult the link:/developer/spark[Neo4j Connector for Apache Spark].  
 
 It offers Spark-2.0 APIs for *RDD, DataFrame, GraphX and GraphFrames*, so you're free to chose how you want to use and process your Neo4j graph data in Apache Spark.
 

--- a/modules/ROOT/pages/apache-spark.adoc
+++ b/modules/ROOT/pages/apache-spark.adoc
@@ -3,8 +3,8 @@
 :page-level: Intermediate
 :author: Neo4j
 :category: integrations
-:tags: integrations, spark, tools
-:description: There are various ways to beneficially use Neo4j with http://spark.apache.org[Apache Spark], here we will list some approaches and point to solutions that enable you to leverage your Spark infrastructure with Neo4j.
+:tags: integrations, spark, tools, deprecated
+:description: This page is deprecated in favor of the Neo4j Connector for Apache Spark
 
 [NOTE]
 **This approach is deprecated** in favor of the link:/developer/spark[Neo4j Connector for Apache Spark].  This page is being maintained

--- a/modules/ROOT/pages/integration.adoc
+++ b/modules/ROOT/pages/integration.adoc
@@ -6,13 +6,21 @@
 [#neo4j-integration]
 Neo4j is supported by a rich ecosystem of libraries, tools, drivers, and guides provided by partners, users, and community contributors.
 We want to give an overview about what's available and link to the original sources.
+
+== Neo4j Supported Connectors
+
+The following integrations are provided by Neo4j and are supported for existing Enterprise customers.
+
+* link:/developer/spark[Neo4j Connector for Apache Spark]
+* link:https://neo4j.com/labs/kafka/4.0/[Neo4j Connector for Apache Kafka] (also known as Neo4j-Streams)
+* link:https://neo4j.com/bi-connector/[Neo4j Connector for Business Intelligence]
+
 We try to focus on the freely available solutions here, and provide links to commercial options were appropriate.
 
-Check out our link:/developer/integration/[integrations] to further boost your Neo4j productivity.
+== Other Community Integrations
 
 Neo4j integration projects:
 
-link:../apache-spark[Neo4j and Apache Spark] +
 link:../elastic-search[Neo4j and Elastic\{Search\}] +
 link:../mongodb[Neo4j and MongoDB] +
 link:../cassandra[Neo4j and Cassandra] +

--- a/modules/ROOT/pages/integration.adoc
+++ b/modules/ROOT/pages/integration.adoc
@@ -7,22 +7,9 @@
 Neo4j is supported by a rich ecosystem of libraries, tools, drivers, and guides provided by partners, users, and community contributors.
 We want to give an overview about what's available and link to the original sources.
 
-== Neo4j Supported Connectors
-
-The following integrations are provided by Neo4j and are supported for existing Enterprise customers.
+Neo4j Connectors are integrations provided by Neo4j and are supported for existing Enterprise customers.
 
 * link:/developer/spark[Neo4j Connector for Apache Spark]
 * link:https://neo4j.com/labs/kafka/4.0/[Neo4j Connector for Apache Kafka] (also known as Neo4j-Streams)
 * link:https://neo4j.com/bi-connector/[Neo4j Connector for Business Intelligence]
 
-We try to focus on the freely available solutions here, and provide links to commercial options were appropriate.
-
-== Other Community Integrations
-
-Neo4j integration projects:
-
-link:../elastic-search[Neo4j and Elastic\{Search\}] +
-link:../mongodb[Neo4j and MongoDB] +
-link:../cassandra[Neo4j and Cassandra] +
-//link:../apache-hadoop[Neo4j and Hadoop] +
-link:../docker[Neo4j and Docker]


### PR DESCRIPTION
**Deploy requested to prod on November 10, not before**

Upcoming availability of the spark connector requires some changes to the developer pages.  Intent of this PR is to:

* Strongly deprecate the old docs with a pointer to the new stuff, but leave the page intact so that people's links don't break.  (If you have a suggestion for doing a redirect instead, this is even better and I'll amend the PR, but didn't want to lose the old information)

* List the supported connectors under the "integrations" section as per agreement with Adam

* Update nav & links