### PR TITLE
Update outdated link in graph embeddings page

### DIFF
--- a/modules/graph-data-science/pages/graph-embeddings.adoc
+++ b/modules/graph-data-science/pages/graph-embeddings.adoc
@@ -70,7 +70,7 @@ It is an implementation of the https://arxiv.org/pdf/1908.11512.pdf[FastRP algor
 It is the fastest of the embedding algorithms and can therefore be useful for obtaining baseline embeddings.
 The embeddings it generates are often equally performant as more complex algorithms that take longer to run.
 
-link:/docs/graph-data-science/1.3-preview/algorithms/alpha/fastrp/fastrp/[Read Random Projection reference documentation^, role="medium button"]
+link:/docs/graph-data-science/current/algorithms/fastrp/[Read Random Projection reference documentation^, role="medium button"]
 
 [#node2Vec]
 node2Vec ::
@@ -79,7 +79,7 @@ The algorithm trains a single-layer feedforward neural network, which is used to
 node2Vec has parameters that can be tuned to control whether the random walks behave more like breadth first or depth first searches.
 This tuning allows the embedding to either capture homophily (similar embeddings capture network communities) or structural equivalence (similar embeddings capture similar structural roles of nodes).
 
-link:/docs/graph-data-science/1.3-preview/algorithms/node-embeddings/node2vec/[Read node2Vec reference documentation^, role="medium button"]
+link:/docs/graph-data-science/current/algorithms/node2vec/[Read node2Vec reference documentation^, role="medium button"]
 
 [#graph-sage]
 GraphSAGE ::
@@ -87,4 +87,4 @@ This https://arxiv.org/pdf/1706.02216.pdf[algorithm^] is the only one that suppo
 Training embeddings that include node properties can be useful for including information beyond the topology of the graph, like meta data, attributes, or the results of other graph algorithms.
 GraphSAGE differs from the other algorithms in that it learns a function to calculate an embedding rather than training individual embeddings for each node.
 
-link:/docs/graph-data-science/1.3-preview/algorithms/alpha/graph-sage/[Read GraphSAGE reference documentation^, role="medium button"]
+link:/docs/graph-data-science/current/algorithms/graph-sage/[Read GraphSAGE reference documentation^, role="medium button"]


### PR DESCRIPTION
Can someone please double-check the links. I don't really know how to test them as locally the page versioning  (1.3, current, etc.. )does not exist.