### PR TITLE
Fix GraphGists URLs

### DIFF
--- a/modules/ROOT/pages/graphgist-portal.adoc
+++ b/modules/ROOT/pages/graphgist-portal.adoc
@@ -1,7 +1,7 @@
 = What is the Neo4j GraphGist Project?
 :level: Beginner
 :page-level: Beginner
-:graphgist: https://neo4j.com/graphgist/
+:graphgist: https://neo4j.com/graphgists/
 :graphgists_list: https://neo4j.com/graphgists/
 :graphgist_portal: http://portal.graphgist.org/
 :author: Neo4j


### PR DESCRIPTION
GraphGists are now available at: `https://neo4j.com/graphgists/` (and not `https://neo4j.com/graphgist/`), for instance https://neo4j.com/graphgists/bank-fraud-detection/