### PR TITLE
Updating JS driver version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -13,7 +13,7 @@ asciidoc:
     spring-boot-version: 2.5.0
     spring-data-neo4j-version: 6.1.1
     java-driver-version: 4.3.3
-    javascript-driver-version: 4.3.0
+    javascript-driver-version: 4.3.1
     python-driver-version: 4.3.1
     dotnet-driver-version: 4.3.0
     go-driver-version: 4.3.1


### PR DESCRIPTION
A new version of the JS driver was released. 

https://www.npmjs.com/package/neo4j-driver/v/4.3.1