### PR TITLE
Update ModelCatalog limitation

### DIFF
--- a/modules/graph-data-science/pages/link-prediction/graph-data-science-library.adoc
+++ b/modules/graph-data-science/pages/link-prediction/graph-data-science-library.adoc
@@ -392,9 +392,7 @@ RETURN modelInfo.bestParameters AS winningModel,
 
 [NOTE]
 ====
-Don't forget that if you are not using the https://neo4j.com/docs/graph-data-science/current/installation/#installation-enterprise-edition[Enterprise Edition] of the Graph Data Science library, you can only have one model in memory at any given time, so you must drop that model, as shown below:
-
-`CALL gds.beta.model.drop('model-only-embedding')`
+Don't forget that if you are not using the https://neo4j.com/docs/graph-data-science/current/installation/#installation-enterprise-edition[Enterprise Edition] of the Graph Data Science library, you can only have a limited number of models in memory at any given time, so you must drop unused models via `CALL gds.beta.model.drop('model-only-embedding')`
 ====
 
 .Results

--- a/modules/graph-data-science/pages/node-classification.adoc
+++ b/modules/graph-data-science/pages/node-classification.adoc
@@ -467,7 +467,7 @@ CALL gds.alpha.ml.nodeClassification.train('marvel_model_data', {
 
 [NOTE]
 ====
-Don't forget that if you are not using the https://neo4j.com/docs/graph-data-science/current/installation/#installation-enterprise-edition[Enterprise Edition] of the Graph Data Science library, you can only have one model in memory at any given time, so you must drop that model via `CALL gds.beta.model.drop('marvel_model_data')`.
+Don't forget that if you are not using the https://neo4j.com/docs/graph-data-science/current/installation/#installation-enterprise-edition[Enterprise Edition] of the Graph Data Science library, you can only have a limited number of models in memory at any given time, so you must drop unused models via `CALL gds.beta.model.drop('marvel_model_data')`.
 ====
 
 This is identical to our procedure before, however, we can see that we have replaced the `featureProperties` to be the FastRP embeddings.  We would expect this model to perform better since the embedding process returns a vector embedding for each node that, in our case, is 250 elements long.  In fact, we obtain the following results with the embeddings:


### PR DESCRIPTION
In 1.6 the limitation for the ModelCatalog was increased to `3` models.
To avoid version dependent information, I opted for a more general description