### PR TITLE
Fix broken apoc documentation links

### DIFF
--- a/modules/cypher/pages/dates-datetimes-durations.adoc
+++ b/modules/cypher/pages/dates-datetimes-durations.adoc
@@ -124,7 +124,7 @@ RETURN article.title AS title,
 | "Dates, Datetimes, and Durations in Neo4j" | 2019-09-25T06:29:39Z | 2019-09-29    | P0M0DT270S
 |===
 
-If we want to format these values we can use https://neo4j.com/docs/labs/apoc/3.4/temporal/temporal-conversions/[temporal functions^] in the APOC library.
+If we want to format these values we can use https://neo4j.com/labs/apoc/4.3/overview/apoc.temporal/[temporal functions^] in the APOC library.
 The following query formats each of the temporal types into more friendly formats:
 
 [source,cypher]
@@ -293,7 +293,7 @@ Below are some resources for learning more about using Temporal types in Neo4j:
 * link:https://neo4j.com/docs/cypher-manual/current/syntax/temporal[Temporal Datatypes^]
 * link:https://neo4j.com/developer/kb/neo4j-string-to-date/[Knowledge Base: Converting strings to dates^]
 * link:https://neo4j.com/developer/neo4j-apoc/[APOC Library^]
-** link:https://neo4j.com/docs/labs/apoc/current/temporal/datetime-conversions/[Date parsing^]
-** link:https://neo4j.com/docs/labs/apoc/3.4/temporal/temporal-conversions/[Temporal Functions^]
+** link:https://neo4j.com/labs/apoc/4.3/overview/apoc.date/apoc.date.format/[Date parsing^]
+** link:https://neo4j.com/labs/apoc/4.3/overview/apoc.temporal/[Temporal Functions^]
 
 include::partial$help.adoc[]


### PR DESCRIPTION
I am not sure we want to hard code apoc version 4.3 documentation, but I don't know what alternative we have.