### PR TITLE
update install instructions for neo4j-php-client

### DIFF
--- a/modules/ROOT/pages/php.adoc
+++ b/modules/ROOT/pages/php.adoc
@@ -57,7 +57,7 @@ It is being actively developed and has a big readme file on the https://github.c
 .Installation
 [source,bash]
 ----
-composer install neo4j-php-client
+composer require laudis/neo4j-php-client
 ----
 
 .Example


### PR DESCRIPTION
Change the composer command from `install` to `require` and specify `laudis/neo4j-php-client` instead of ambiguous `neo4j-php-client`