### PR TITLE
link CTA, elements of standardization for programming language pages

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,6 +8,7 @@ asciidoc:
   attributes:
     page-theme: developer
     img: https://dist.neo4j.com/wp-content/uploads/
+    aura_signup: https://neo4j.com/cloud/aura/?ref=developer-guides
     neo4j-version: 4.2.7
     neo4j-ogm-version: 3.2.23
     spring-boot-version: 2.5.0

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -64,7 +64,7 @@
 ** xref:dotnet.adoc[.NET]
 ** xref:javascript.adoc[JavaScript]
 ** xref:python.adoc[Python]
-** xref:go.adoc[Go,title="Go Programming Language"]
+** xref:go.adoc[Go]
 ** xref:ruby.adoc[Ruby]
 ** xref:php.adoc[PHP]
 ** xref:erlang-elixir.adoc[Erlang &amp; Elixir]

--- a/modules/ROOT/pages/_includes/aura_cta.adoc
+++ b/modules/ROOT/pages/_includes/aura_cta.adoc
@@ -7,4 +7,4 @@ ifndef::cta-header[]
 endif::[]
 Free forever, no credit card required.
 
-link:https://neo4j.com/cloud/aura/?ref=developer-guides[Start on AuraDB,role=button]
+link:{aura_signup}[Start on AuraDB,role=button]

--- a/modules/ROOT/pages/_includes/common-language-prereq.adoc
+++ b/modules/ROOT/pages/_includes/common-language-prereq.adoc
@@ -1,4 +1,4 @@
 .Prerequisites
 [abstract]
 You should be familiar with link:https://neo4j.com/docs/getting-started/current/graphdb-concepts/[graph database concepts] and the property graph model.
-You should have link:/download[installed Neo4j] and made yourself familiar with our link:/developer/cypher[Cypher Query language].
+You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or link:/download/[installed Neo4j locally]

--- a/modules/ROOT/pages/dotnet.adoc
+++ b/modules/ROOT/pages/dotnet.adoc
@@ -21,11 +21,8 @@ include::./_includes/common-language-prereq.adoc[]
 
 image::{img}dotnet-logo.png[float=right,width=300]
 
-The .NET platform allows developers to create fascinating applications utilizing graph concepts with Neo4j.
-
-Neo4j aims to have a great experience on Windows with an desktop installer and dedicated PowerShell modules.
-
-With the Neo4j 3.0 release we are happy to provide an officially supported driver for .NET.
+Neo4j provides drivers which allow you to make a connection to the database and develop applications
+which create, read, update, and delete information from the graph.
 
 [#dotnet-driver]
 == Neo4jDotNetDriver

--- a/modules/ROOT/pages/erlang-elixir.adoc
+++ b/modules/ROOT/pages/erlang-elixir.adoc
@@ -11,10 +11,7 @@
 [abstract]
 {description}
 
-.Prerequisites
-[abstract]
-You should be familiar with xref:graph-database.adoc[graph database concepts] and the property graph model.
-You should have link:/download/[installed Neo4j^] and made yourself familiar with our link:/developer/cypher-query-language/[Cypher query language].
+include::./_includes/common-language-prereq.adoc[]
 
 [role=expertise {level}]
 {level}

--- a/modules/ROOT/pages/go.adoc
+++ b/modules/ROOT/pages/go.adoc
@@ -21,7 +21,8 @@ include::./_includes/common-language-prereq.adoc[]
 
 image::{img}GO.jpg[width=150,float=right]
 
-You can use the official driver for Go (neo4j-go-driver) or connect via Bolt or HTTP with any of our community drivers.
+Neo4j provides drivers which allow you to make a connection to the database and develop applications
+which create, read, update, and delete information from the graph.
 
 [#go-driver]
 == Neo4j Go Driver

--- a/modules/ROOT/pages/graph-database.adoc
+++ b/modules/ROOT/pages/graph-database.adoc
@@ -76,7 +76,7 @@ If you'd like to learn more about any of these, you can read more about link:/de
 
 Neo4j is an open-source, NoSQL, native graph database that provides an ACID-compliant transactional backend for your applications that has been publicly available since 2007.
 
-Neo4j is offered as a managed service via link:https://neo4j.com/cloud/aura/?ref=developer-guides[AuraDB].
+Neo4j is offered as a managed service via link:{aura_signup}[AuraDB].
 But you can also run Neo4j yourself with either Community Edition or Enterprise Edition. 
 The Enterprise Edition includes all that Community Edition has to offer, plus extra enterprise requirements such as backups, clustering, and failover abilities.  Neo4j is written in Java and Scala, and the source code is available on https://github.com/neo4j/neo4j[GitHub^].
 

--- a/modules/ROOT/pages/guide-import-csv.adoc
+++ b/modules/ROOT/pages/guide-import-csv.adoc
@@ -70,7 +70,7 @@ More information is in the manual page on link:/docs/operations-manual/3.5/tools
 This can be an easy thing to miss and end up with an access error, so we will try to clarify the rules here.
 
 *Local files* may be loaded using a `file:///` prefix before the file name.  +
-Because link:https://neo4j.com/cloud/aura/?ref=developer-guides[AuraDB] is cloud based, this local file approach will not work with AuraDB and only local installations.
+Because link:{aura_signup}[AuraDB] is cloud based, this local file approach will not work with AuraDB and only local installations.
 
 Neo4j security has a default setting that local files can only be read from the Neo4j import directory, which is different based on your operating system.
 File locations for each OS are listed in our {opsmanual}/configuration/file-locations[Neo4j Operations Manual^].

--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -23,10 +23,8 @@ When developing with Neo4j, please use Java 8 or 11 and your favorite IDE.
 
 image::{img}java.jpg[float=right,width=200]
 
-:cta-header: The Fastest Way to get Started with Java & Graphs
-include::./_includes/aura_cta.adoc[]
-
-Alternatively, Neo4j can be installed on any system and then accessed via its bolt APIs. We recommend the official driver for Java for any JVM language.
+Neo4j provides drivers which allow you to make a connection to the database and develop applications
+which create, read, update, and delete information from the graph.
 
 For Community Edition and Enterprise Edition, you can also extend Neo4j by implementing *user defined procedures for Cypher* in Java or other JVM languages.
 

--- a/modules/ROOT/pages/javascript.adoc
+++ b/modules/ROOT/pages/javascript.adoc
@@ -22,11 +22,8 @@ include::./_includes/common-language-prereq.adoc[]
 
 image::{img}nodejs.png[float=right,width=300]
 
-:cta-header: The Fastest Way to get Started with JavaScript & Graphs
-include::./_includes/aura_cta.adoc[]
-
-Alternatively, Neo4j can be installed on any system and then accessed via its bolt APIs. We recommend the official driver for JS (neo4j-driver).
-
+Neo4j provides drivers which allow you to make a connection to the database and develop applications
+which create, read, update, and delete information from the graph.
 
 [#javascript-driver]
 == Neo4j Javascript Driver

--- a/modules/ROOT/pages/neo4j-apoc.adoc
+++ b/modules/ROOT/pages/neo4j-apoc.adoc
@@ -46,7 +46,7 @@ Before you begin to write adhoc functions for your application, be sure check AP
 [#installing-apoc]
 == Installing the APOC Library
 
-If you're using link:https://neo4j.com/cloud/aura/?ref=developer-guides[AuraDB] congratulations, you're already done with this section.  
+If you're using link:{aura_signup}[AuraDB] congratulations, you're already done with this section.  
 https://neo4j.com/docs/aura/current/getting-started/apoc/[A subset of APOC core functionality^] is already built in.  The rest of this section is for users who run Neo4j in a self-managed mode.
 
 If you haven't already, http://neo4j.org/download/[download] Neo4j Desktop and use the provided instructions (shown when downloading) to get a project and database ready to run.

--- a/modules/ROOT/pages/perl.adoc
+++ b/modules/ROOT/pages/perl.adoc
@@ -12,10 +12,7 @@
 {description}
 While this guide is not comprehensive, it will introduce some prominent drivers and link to the relevant resources.
 
-.Prerequisites
-[abstract]
-You should be familiar with xref:graph-database.adoc[graph database concepts] and the property graph model.
-You should have link:/download/[installed Neo4j^] and made yourself familiar with our link:/developer/cypher-query-language/[Cypher query language^].
+include::./_includes/common-language-prereq.adoc[]
 
 [role=expertise {level}]
 {level}

--- a/modules/ROOT/pages/php.adoc
+++ b/modules/ROOT/pages/php.adoc
@@ -12,11 +12,8 @@
 {description}
 While this guide is not comprehensive it will introduce the different drivers and link to the relevant resources.
 
-.Prerequisites
-[abstract]
-You should be familiar with link:/developer/graph-database/[graph database concepts] and the property graph model, have link:/download/[installed Neo4j] and made yourself familiar with our link:/developer/cypher-query-language/[Cypher query language]. You should naturally have PHP installed on your machine and link:https://getcomposer.org/[composer ^]for easy installation of the driver.
-
-If you have any questions, you can always find a community member around on the https://community.neo4j.com[Neo4j Online Community^].
+include::./_includes/common-language-prereq.adoc[]
+When developing with Neo4j, please use Java 8 or 11 and your favorite IDE.
 
 [role=expertise {level}]
 {level}

--- a/modules/ROOT/pages/python.adoc
+++ b/modules/ROOT/pages/python.adoc
@@ -11,11 +11,7 @@
 [abstract]
 {description}
 
-.Prerequisites
-[abstract]
-* You should be familiar with link:/developer/graph-database/[graph database concepts] and the property graph model.
-* You should have link:/download/[installed Neo4j] and made yourself familiar with our link:/developer/cypher-query-language/[Cypher query language].
-* We also recommend installing and becoming familiar with both https://pip.pypa.io/[pip^] and https://virtualenv.pypa.io/[virtualenv^] before working on a Python project.
+include::./_includes/common-language-prereq.adoc[]
 
 [role=expertise {level}]
 {level}
@@ -25,10 +21,8 @@
 
 image::{img}python-logo.png[width=300,float="right"]
 
-:cta-header: The Fastest Way to get Started with Python & Graphs
-include::./_includes/aura_cta.adoc[]
-
-Alternatively, Neo4j can be installed on any system and then accessed via its bolt APIs. We recommend the official driver for Python (neo4j-python-driver) or connect via HTTP with any of our community drivers.
+Neo4j provides drivers which allow you to make a connection to the database and develop applications
+which create, read, update, and delete information from the graph.
 
 [#python-driver]
 == Neo4j Python Driver

--- a/modules/ROOT/pages/ruby.adoc
+++ b/modules/ROOT/pages/ruby.adoc
@@ -4,9 +4,6 @@
 :section: Develop with Neo4j
 :section-link: language-guides
 :sectanchors:
-:toc:
-:toc-title: Contents
-:toclevels: 1
 :author: Neo4j
 :programming-language: ruby
 :category: drivers

--- a/modules/ROOT/pages/spring-data-neo4j.adoc
+++ b/modules/ROOT/pages/spring-data-neo4j.adoc
@@ -14,7 +14,7 @@ The library provides convenient access to Neo4j including object mapping, Spring
 .Prerequisites
 [abstract]
 * Familiarity with xref:graph-database.adoc[graph database] concepts and the xref:graph-database.adoc#property-graph[property graph model].
-* link:https://neo4j.com/cloud/aura/?ref=developer-guides[Create an AuraDB Free instance] and familiarity with the link:/developer/cypher-query-language[Cypher query language]
+* link:{aura_signup}[Create an AuraDB Free instance] and familiarity with the link:/developer/cypher-query-language[Cypher query language]
 * Some knowledge/experience with Spring.
 Knowing https://projects.spring.io/spring-data/[Spring Data^] and https://projects.spring.io/spring-boot/[Spring Boot^] are both great additions to your toolbox, as well.
 * For this library, please use JDK 11 or later and your favorite IDE.

--- a/modules/cypher/pages/procedures-functions.adoc
+++ b/modules/cypher/pages/procedures-functions.adoc
@@ -111,7 +111,7 @@ If they are open source, check their source-code and best build them yourself.
 
 [IMPORTANT]
 Certain procedures and functions are available for self-managed Neo4j Enterprise Edition and Community Edition.  Custom code
-described in this section is not compatible with link:https://neo4j.com/cloud/aura/?ref=developer-guides[AuraDB]
+described in this section is not compatible with link:{aura_signup}[AuraDB]
 
 [#procedure-function-gallery]
 == Procedure and Function Gallery


### PR DESCRIPTION
- Make PL pages more consistent with pre-requisites &. pre-ambles
- Templatize Aura links throughout
- Remove CTA buttons on PL pages in favor of a prerequisite step (set up a database)