### PR TITLE
update spark links to official product docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -78,7 +78,7 @@
 ** xref:ruby-course.adoc[Tutorial: Ruby &amp; Rails (Books)]
 
 * xref:integration.adoc[Neo4j Tools &amp; Integrations]
-** link:https://neo4j.com/developer/spark/[Neo4j Connector for Apache Spark]
+** link:https://neo4j.com/docs/spark/current/[Neo4j Connector for Apache Spark]
 ** link:https://neo4j.com/labs/kafka/4.0/[Neo4j Connector for Apache Kafka]
 ** link:https://neo4j.com/bi-connector/[Neo4j Connector for Business Intelligence]
 

--- a/modules/ROOT/pages/apache-spark.adoc
+++ b/modules/ROOT/pages/apache-spark.adoc
@@ -7,7 +7,7 @@
 :description: This page is deprecated in favor of the Neo4j Connector for Apache Spark
 
 [NOTE]
-**This approach is deprecated** in favor of the link:/developer/spark[Neo4j Connector for Apache Spark].  This page is being maintained
+**This approach is deprecated** in favor of the link:/docs/spark/current/[Neo4j Connector for Apache Spark].  This page is being maintained
 for reference, but is not current or supported.  Please consult the Neo4j Connector for Apache Spark for the latest supported connector.
 
 .Goals
@@ -48,7 +48,7 @@ The https://github.com/neo4j-contrib/neo4j-spark-connector[Neo4j Spark Connector
 
 [NOTE]
 **The information on this page refers to the old (2.4.5 release) of the spark connector**.   For more up to date information, an easier and more modern API, 
-consult the link:/developer/spark[Neo4j Connector for Apache Spark].  
+consult the link:/docs/spark/current/[Neo4j Connector for Apache Spark].  
 
 It offers Spark-2.0 APIs for *RDD, DataFrame, GraphX and GraphFrames*, so you're free to chose how you want to use and process your Neo4j graph data in Apache Spark.
 

--- a/modules/ROOT/pages/integration.adoc
+++ b/modules/ROOT/pages/integration.adoc
@@ -9,7 +9,7 @@ We want to give an overview about what's available and link to the original sour
 
 Neo4j Connectors are integrations provided by Neo4j and are supported for existing Enterprise customers.
 
-* link:/developer/spark[Neo4j Connector for Apache Spark]
+* link:https://neo4j.com/docs/spark/current/[Neo4j Connector for Apache Spark]
 * link:https://neo4j.com/labs/kafka/4.0/[Neo4j Connector for Apache Kafka] (also known as Neo4j-Streams)
 * link:https://neo4j.com/bi-connector/[Neo4j Connector for Business Intelligence]
 


### PR DESCRIPTION
documentation team recently migrated spark connector docs to the official docs. This is simply updating links to ensure that they aren't hitting the redirect URL