### PR TITLE
update menu items

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -180,11 +180,13 @@
 ** link:https://neo4j.com/videos/[Neo4j Videos^]
 ** link:https://neo4j.com/speaker-program/[Speaker Program: Share your Story^]
 
-* link:https://community.neo4j.com/[Help Forums^]
+* Community Support
+** link:https://community.neo4j.com/[Community Forum^]
 ** link:https://discord.gg/neo4j[Discord Chat^]
 ** link:https://stackoverflow.com/questions/tagged/neo4j[StackOverflow^]
 
-* link:https://neo4j.com/graphacademy/[Learn with GraphAcademy^]
+* Learn with GraphAcademy
+** link:https://neo4j.com/graphacademy/[Online Courses^]
 ** link:https://neo4j.com/graphacademy/neo4j-certification/[Neo4j Certification^]
 
 * xref:resources.adoc[Documentation &amp; Resources]


### PR DESCRIPTION
This PR updates a Community Help and Graphacademy related menu items in /developer section.

The Problems - there were a few menu items that had external link to the root items (meaning when you click on them, they open a new link in new tab), but they also have sub items which are supposed to be expanded when the root item is clicked. This is not ideal and is challenging to provide correct affordance to the user.

So I have updated the menu items to address it.

Haven't put too much thought to the title of the menu items, so feel free to suggest better titles.