### PR TITLE
Update CLA email address

### DIFF
--- a/modules/ROOT/pages/cla.adoc
+++ b/modules/ROOT/pages/cla.adoc
@@ -6,64 +6,53 @@
 [#cla-summary]
 == Summary
 
-We require all source code that is hosted on the Neo4j infrastructure to be contributed through the http://dist.neo4j.org/neo4j-cla.pdf[Neo4j Contributor License Agreement] (CLA).
+We require all source code that is hosted on the Neo4j infrastructure to be contributed through the http://dist.neo4j.org/neo4j-cla.pdf[Neo4j Contributor License Agreement^] (CLA).
 
-The purpose of the Neo4j Contributor License Agreement is to protect the integrity of the code base, which in turn protects the community around that code base: the founding entity Neo4j Inc, the Neo4j developer community, and Neo4j users.
+The purpose of the Neo4j Contributor License Agreement is to protect the integrity of the code base, which, in turn, protects the community around that code base: the founding entity (Neo4j, Inc.), the Neo4j developer community, and Neo4j users.
 
-This kind of contributor agreement is common amongst free software and open source projects (it is in fact very similar to the widely signed  http://www.oracle.com/technetwork/community/oca-486395.html[Oracle Contributor Agreement]).
+This kind of contributor agreement is common amongst free software and open source projects (it is, in fact, very similar to the widely-signed http://www.oracle.com/technetwork/community/oca-486395.html[Oracle Contributor Agreement^]).
 
-Please see the below or send a mail to cla (@t) neo4j dot com if you have any other questions about the intent of the CLA.
-If you have a legal question, please ask a lawyer.
+Please see the below or send an email to cla@neo4j.com if you have any other questions about the intent of the CLA. If you have a legal question, please ask a lawyer.
 
 [#common-questions]
 == Common questions
 
 === Am I losing the rights to my own code?
 
-No, the http://dist.neo4j.org/neo4j-cla.pdf[Neo4j CLA] only asks you to _share_ your rights, not relinquish them.
-Unlike some contribution agreements that require you to transfer copyrights to another organization, the CLA does not take away your rights to your contributed intellectual property.
-When you agree to the CLA, you grant us joint ownership in copyright, and a patent license for your contributions.
-You retain all rights, title, and interest in your contributions and may use them for any purpose you wish.
-Other than revoking our rights, you can still do whatever you want with your code.
+No, the http://dist.neo4j.org/neo4j-cla.pdf[Neo4j CLA^] only asks you to _share_ your rights, not relinquish them.
+
+Unlike some contribution agreements that require you to transfer copyrights to another organization, the CLA does not take away your rights to your contributed intellectual property. When you agree to the CLA, you grant us joint ownership in copyright, and a patent license for your contributions. You retain all rights, title, and interest in your contributions and may use them for any purpose you wish. Other than revoking our rights, you can still do whatever you want with your code.
 
 === What can you do with my contribution?
 
-We may exercise all rights that a copyright holder has, as well as the rights you grant in the http://dist.neo4j.org/neo4j-cla.pdf[Neo4j CLA] to use any patents you have in your contributions.
-As the CLA provides for joint copyright ownership, you may exercise the same rights as we in your contributions.
+We may exercise all rights that a copyright holder has, as well as the rights you grant in the http://dist.neo4j.org/neo4j-cla.pdf[Neo4j CLA^] to use any patents you have in your contributions. As the CLA provides for joint copyright ownership, you may exercise the same rights as we in your contributions.
 
 === What are the community benefits of this?
 
-Well, it allows us to sponsor the Neo4j projects and provide an infrastructure for the community, while making sure that we can include this in software that we ship to our customers without any nasty surprises.
-Without this ability, we as a small company would be hard pressed to release all our code as free software.
+It allows us to sponsor the Neo4j projects and provide an infrastructure for the community, while making sure that we can include this in software that we ship to our customers without any nasty surprises. Without this ability, we as a small company would be hard pressed to release all our code as free software.
 
-Moreover, the CLA lets us protect community members (both developers and users) from hostile intellectual property litigation should the need arise.
-This is in line with how other free software stewards like the http://www.fsf.org[Free Software Foundation -- FSF] defend projects (except with the FSF, there's no shared copyright but instead you completely sign it over to the FSF).
-The contributor agreement also includes a "free software covenant," or a promise that a contribution will remain available as free software.
+Moreover, the CLA lets us protect community members (both developers and users) from hostile intellectual property litigation should the need arise. This is in line with how other free software stewards like the http://www.fsf.org[Free Software Foundation -- FSF^] defend projects (except with the FSF, there's no shared copyright but instead you completely sign it over to the FSF). The contributor agreement also includes a "free software covenant," or a promise that a contribution will remain available as free software.
 
 At the end of the day, you still retain all rights to your contribution and we can stand confident that we can protect the Neo4j community and the Neo4j, Inc. customers.
 
 === Can we discuss some items in the CLA?
 
-Absolutely! Please give us feedback! But let's keep the legalese off the mailing lists.
-Please mail your feedback directly to cla (@t) neo4j dot com and we'll get back to you.
+Absolutely! Please give us feedback! But let's keep the legalese off the mailing lists. Please mail your feedback directly to cla@neo4j.com and we'll get back to you.
 
 === I still don't like this CLA
 
-That's fine.
-You can still host it anywhere else, of course.
-Please do!
-We're only talking here about the rules for the infrastructure that we provide.
+That's fine. You can still host it anywhere else, of course. Please do! We're only talking here about the rules for the infrastructure that we provide.
 
 [#sign-cla]
 == How to sign
 
-When you've read through the CLA, please send a mail to cla (@t) neotechnology dot com.
+When you've read through the CLA, please send a mail to cla@neo4j.com.
 Include the following information:
 
 * Your full name.
 * Your e-mail address.
 * Your GitHub username.
-* An attached copy of the https://dist.neo4j.org/neo4j-cla.pdf[Neo4j CLA].
+* An attached copy of the https://dist.neo4j.org/neo4j-cla.pdf[Neo4j CLA^].
 * That you agree to its terms.
 
 For example:


### PR DESCRIPTION
Syntax is currently really confusing on current page....I think the cla@neo4j.com text has been re-formatted or not translated from another format correctly. https://neo4j.com/developer/cla/

Example of current:
cla (@t) neo4j dot com

Should be:
cla@neo4j.com