### PR TITLE
Neo4j and GraphQL: Fix index.js, use async getSchema()

### DIFF
--- a/modules/ROOT/pages/graphql.adoc
+++ b/modules/ROOT/pages/graphql.adoc
@@ -163,12 +163,12 @@ const typeDefs = gql`
     title: String!
     year: Int
     plot: String
-    actors: [Person] @relationship(type: "ACTED_IN", direction: IN)
+    actors: [Person!]! @relationship(type: "ACTED_IN", direction: IN)
   }
 
   type Person {
     name: String!
-    movies: [Movie] @relationship(type: "ACTED_IN", direction: OUT)
+    movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
   }
 `;
 
@@ -179,12 +179,14 @@ const driver = neo4j.driver(
 
 const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
 
-const server = new ApolloServer({
-  schema: neoSchema.schema,
-});
+neoSchema.getSchema().then((schema) => {
+    const server = new ApolloServer({
+        schema: schema
+    });
 
-server.listen().then(({ url }) => {
-  console.log(`GraphQL server ready on ${url}`);
+    server.listen().then(({ url }) => {
+        console.log(`GraphQL server ready on ${url}`);
+    });
 });
 ----
 


### PR DESCRIPTION
The code snippet to generate the schema and then start the server was not updated with the changes made in `@neo4j/graphql` version 3.0.0.

