### PR TITLE
Update Building Applications links to GA

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -77,7 +77,7 @@
 ** xref:perl.adoc[Perl]
 
 * Building Applications
-** xref:example-project.adoc[Example: all Stacks (Movies)]
+// ** xref:example-project.adoc[Example: all Stacks (Movies)]
 ** xref:https://graphacademy.neo4j.com/courses/app-java/[Building Apps with Java]
 ** xref:https://graphacademy.neo4j.com/courses/app-python/[Building Apps with Python]
 ** xref:https://graphacademy.neo4j.com/courses/app-nodejs/[Building Apps with Node.js]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -78,11 +78,11 @@
 
 * Building Applications
 // ** xref:example-project.adoc[Example: all Stacks (Movies)]
-** xref:https://graphacademy.neo4j.com/courses/app-java/[Building Apps with Java]
-** xref:https://graphacademy.neo4j.com/courses/app-python/[Building Apps with Python]
-** xref:https://graphacademy.neo4j.com/courses/app-nodejs/[Building Apps with Node.js]
-** xref:https://graphacademy.neo4j.com/courses/app-dotnet/[Building Apps with .NET]
-** xref:https://graphacademy.neo4j.com/courses/app-go/[Building Apps with Go]
+** link:https://graphacademy.neo4j.com/courses/app-java/[Building Apps with Java]
+** link:https://graphacademy.neo4j.com/courses/app-python/[Building Apps with Python]
+** link:https://graphacademy.neo4j.com/courses/app-nodejs/[Building Apps with Node.js]
+** link:https://graphacademy.neo4j.com/courses/app-dotnet/[Building Apps with .NET]
+** link:https://graphacademy.neo4j.com/courses/app-go/[Building Apps with Go]
 
 // ** xref:js-movie-app.adoc[Tutorial: JavaScript/Express and React (IMDB)]
 // ** xref:ruby-course.adoc[Tutorial: Ruby &amp; Rails (Books)]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -80,10 +80,14 @@
 
 * Building Applications
 ** xref:example-project.adoc[Example: all Stacks (Movies)]
-// TODO Adam ** xref:building-applications:using-drivers.adoc[Tutorial: Step By Step - Connect and Query Neo4j]
-** xref:python-movie-app.adoc[Tutorial: Python/Flask and React (IMDB)]
-** xref:js-movie-app.adoc[Tutorial: JavaScript/Express and React (IMDB)]
-** xref:ruby-course.adoc[Tutorial: Ruby &amp; Rails (Books)]
+** xref:https://graphacademy.neo4j.com/courses/app-java/[Building Apps with Java]
+** xref:https://graphacademy.neo4j.com/courses/app-python/[Building Apps with Python]
+** xref:https://graphacademy.neo4j.com/courses/app-nodejs/[Building Apps with Node.js]
+** xref:https://graphacademy.neo4j.com/courses/app-dotnet/[Building Apps with .NET]
+** xref:https://graphacademy.neo4j.com/courses/app-go/[Building Apps with Go]
+
+// ** xref:js-movie-app.adoc[Tutorial: JavaScript/Express and React (IMDB)]
+// ** xref:ruby-course.adoc[Tutorial: Ruby &amp; Rails (Books)]
 
 * xref:integration.adoc[Neo4j Tools &amp; Integrations]
 ** link:https://neo4j.com/docs/spark/current/[Neo4j Connector for Apache Spark]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -64,15 +64,13 @@
 *** Courses:
 **** link:https://graphacademy.neo4j.com/courses/app-java/[Building Neo4j Applications with Java^]
 ** xref:dotnet.adoc[.NET]
+*** link:https://graphacademy.neo4j.com/courses/app-dotnet/[Building Neo4j Applications with .NET^]
 ** xref:javascript.adoc[JavaScript]
-*** Courses:
-**** link:https://graphacademy.neo4j.com/courses/app-nodejs/[Building Neo4j Applications with Node.js^]
+*** link:https://graphacademy.neo4j.com/courses/app-nodejs/[Building Neo4j Applications with Node.js^]
 ** xref:python.adoc[Python]
-*** Courses:
-**** link:https://graphacademy.neo4j.com/courses/app-python/[Building Neo4j Applications with Python^]
+*** link:https://graphacademy.neo4j.com/courses/app-python/[Building Neo4j Applications with Python^]
 ** xref:go.adoc[Go]
-*** Courses:
-**** link:https://graphacademy.neo4j.com/courses/app-go/[Building Neo4j Applications with Go^]
+*** link:https://graphacademy.neo4j.com/courses/app-go/[Building Neo4j Applications with Go^]
 ** xref:ruby.adoc[Ruby]
 ** xref:php.adoc[PHP]
 ** xref:erlang-elixir.adoc[Erlang &amp; Elixir]

--- a/modules/ROOT/pages/example-project.adoc
+++ b/modules/ROOT/pages/example-project.adoc
@@ -5,6 +5,7 @@
 :category: drivers
 :tags: examples, app-development, project, applications
 :description: This guide explains the example application we use to introduce the different Neo4j drivers in detail.
+:redirect: https://graphacademy.neo4j.com/courses/developer/
 
 .Goals
 [abstract]

--- a/modules/ROOT/pages/js-movie-app.adoc
+++ b/modules/ROOT/pages/js-movie-app.adoc
@@ -6,6 +6,7 @@
 :tags: node, express, javascript, react
 :description: This course provides an overview on everything that you need to build a Neo4j application with the link:https://en.wikipedia.org/wiki/JavaScript[JavaScript programming language^].
 The Express framework is used as the backend, and the React framework as front-end.
+:redirect: https://graphacademy.neo4j.com/courses/app-nodejs/
 
 
 .Goals

--- a/modules/ROOT/pages/python-movie-app.adoc
+++ b/modules/ROOT/pages/python-movie-app.adoc
@@ -6,6 +6,7 @@
 :tags: flask, python, react
 :description: This course provides an overview on everything that you need to build a Neo4j application with the link:https://www.python.org/[Python programming language^].
 The Flask framework is used as the backend, and React as front-end.
+:redirect: https://graphacademy.neo4j.com/courses/app-python/
 
 
 .Goals


### PR DESCRIPTION
I noticed some feedback that these links were out of date.

- Updated links in navigation
- Redirect /developer/example-project/ to GraphAcademy
- Redirects on Flask and JavaScript courses