### PR TITLE
Remove name attribute

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -21,10 +21,8 @@ asciidoc:
     testcontainers-version: 1.15.3
     maven-sdn: Package
     maven-artifact-info: https://search.maven.org/artifact/org.neo4j.driver/neo4j-java-driver/{java-driver-version}/jar
-
     examples: https://github.com/neo4j-examples
     cyphermanual: 'https://neo4j.com/docs/cypher-manual/current'
     drivermanual: 'https://neo4j.com/docs/driver-manual/current'
     opsmanual: 'https://neo4j.com/docs/operations-manual/current'
     github: 'https://github.com/neo4j-contrib/developer-resources/tree/gh-pages'
-    name: '{name}'


### PR DESCRIPTION
The value `{name}` won't be resolved and I don't think we want to display the value `{name}`. Since I didn't find any reference to `{name}`, I've decided to remove it.

```
[12:18:13.284] WARN (@antora/asciidoc-loader): Skipping reference to missing attribute 'name' in value of 'name' attribute
    file: antora.yml
    source: https://github.com/neo4j-documentation/developer-guides.git (branch: publish)
```