### PR TITLE
Fix image resource id

### DIFF
--- a/modules/ROOT/pages/tools-graph-visualization.adoc
+++ b/modules/ROOT/pages/tools-graph-visualization.adoc
@@ -179,7 +179,7 @@ Bloom is available in the following formats:
 * Product information: https://neo4j.com/bloom/[Neo4j Bloom landing page^]
 
 ==== *NeoDash* by
-image:/developer/_images/labs-logo.jpg[width=200]
+image:labs-logo.jpg[width=200]
 
 image::https://neo4j.com/labs/neodash/_images/neodash.png[role="popup-link",float="right",width=350]
 


### PR DESCRIPTION
We should not use a relative path on Antora but a resource id: https://docs.antora.org/antora/latest/page/resource-id/#whats-a-resource-id

```
[12:18:23.559] ERROR (asciidoctor): target of image not found: /developer/_images/labs-logo.jpg
    file: modules/ROOT/pages/tools-graph-visualization.adoc
    source: https://github.com/neo4j-documentation/developer-guides.git (branch: publish)
```