### PR TITLE
Add warning regarding neomodel

### DIFF
--- a/modules/ROOT/pages/python.adoc
+++ b/modules/ROOT/pages/python.adoc
@@ -96,6 +96,9 @@ alice, bob, carol = [result.one for result in tx.commit()]
 
 image::{img}neomodel.200x80.png[float="right",width=100]
 
+Warning: The project is currently not actively maintained and should not be used in production. It has last been released in 2021. Newer neo4j versions are not supported. Critical bugs might exist.  
+
+
 An Object Graph Mapper built on top of the Neo4j python driver.
 Familiar Django style node definitions with a powerful query API, thread safe and full transaction support.
 A Django plugin https://github.com/neo4j-contrib/django-neomodel[django_neomodel^] is also available.


### PR DESCRIPTION
I have tried to get in contact with the maintainers of neomodel via their issues, with no response. 

There are easy issues that are open for over half a year (https://github.com/neo4j-contrib/neomodel/issues/627) and pull requests that do not get merged. Currently the project is not usable.