### PR TITLE
Clarify vector index dimension guidance

### DIFF
--- a/modules/genai-ecosystem/pages/vector-search.adoc
+++ b/modules/genai-ecosystem/pages/vector-search.adoc
@@ -29,6 +29,8 @@ image::https://cdn.graphacademy.neo4j.com/assets/img/courses/banners/llm-vectors
 This page covers Neo4j `5.11+`.
 The tabs below separate the current recommended approach using Cypher 25 from the compatibility approach for earlier Neo4j `5.x` releases using Cypher 5.
 For current Neo4j releases, prefer the Cypher 25 approach, using the https://neo4j.com/docs/cypher-manual/current/clauses/search/[`SEARCH` clause^] for vector search and https://neo4j.com/docs/genai/plugin/current/embeddings/[`ai.text.embed()` and `ai.text.embedBatch()`^] for generating embeddings.
+In both approaches, explicitly set `vector.dimensions` to match the embedding model you use. 
+This is recommended because it ensures only embeddings of the expected size are indexed and causes mismatched-dimension queries to fail clearly.
 
 [.tabbed-example]
 ====


### PR DESCRIPTION
## Summary
- make the vector-search guide explicitly recommend setting `vector.dimensions` when creating the index
- clarify that the dimension should match the embedding model in use
- explain that mismatched-dimension queries fail clearly

## Validation
- `git diff --check`
- `npm run build` (the repo still emits existing unrelated include and section-order warnings outside this page)
