### PR TITLE
Clarify hybrid search query vector dimensions

### DIFF
--- a/modules/genai-ecosystem/pages/vector-search.adoc
+++ b/modules/genai-ecosystem/pages/vector-search.adoc
@@ -212,6 +212,8 @@ ORDER BY wrrf DESC, abstract.id ASC;
 ----
 
 For example, pass parameters like these from an application:
+The `queryVector` below is shortened for readability.
+In a real query, pass an embedding with the same dimensions as the vector index, for example 1536 dimensions when using `text-embedding-3-small`.
 
 [source,json]
 ----


### PR DESCRIPTION
## Summary

- Clarifies that the hybrid search JSON query vector is shortened for readability.
- Tells readers to pass an embedding with the same dimensions as the vector index.

## Validation

- Text-only docs change.
- Hybrid example was runtime-validated separately with docs-meta against Neo4j 2026.01.